### PR TITLE
feat(tools/vps): support start / stop endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,9 @@ USER node
 
 WORKDIR /home/node
 
-COPY ./dist/ .
+COPY --chown=node:node ./dist/ .
 
-COPY ./package*.json ./
-
+COPY --chown=node:node ./package*.json ./
 
 RUN npm ci --omit=dev
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@
 
 ---
 
+## 📋 Requirements
+
+Node.js: v22
+
+OVHcloud API credentials : https://www.ovh.com/auth/api/createToken
+
+---
+
 ## 🚀 Quick Start
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 services:
-    ovh-mcp:
+    server:
+        user: '1000:1000'
         build: .
         ports:
             - '8000:8000'
         volumes:
-            - .env:/home/node/.env
+            - ./.env:/home/node/.env
         environment:
             - NODE_ENV=production

--- a/src/tools/vps/README.md
+++ b/src/tools/vps/README.md
@@ -76,10 +76,10 @@ Covers Virtual Private Servers API actions
 - [ ] DEL /vps/{serviceName}/snapshot
 - [ ] GET /vps/{serviceName}/snapshot/download
 - [ ] POST /vps/{serviceName}/snapshot/revert
-- [ ] POST /vps/{serviceName}/start
+- [x] POST /vps/{serviceName}/start
 - [ ] GET /vps/{serviceName}/statistics
 - [ ] GET /vps/{serviceName}/status
-- [ ] POST /vps/{serviceName}/stop
+- [x] POST /vps/{serviceName}/stop
 - [ ] GET /vps/{serviceName}/tasks
 - [ ] GET /vps/{serviceName}/tasks/{id}
 - [ ] GET /vps/{serviceName}/templates

--- a/src/tools/vps/service.ts
+++ b/src/tools/vps/service.ts
@@ -113,7 +113,7 @@ export const getConsoleUrlVPSServiceTool = createTool(
 
 export const getIPAddressesVPSServiceTool = createTool(
     'vps_service_get_ip_addresses',
-    'Return IP addresses associated to given VPS',
+    'Return IP addresses associated to given VPS. Use it whenever tool asks for VPS ip address',
     {
         serviceName: serviceName,
     },
@@ -193,6 +193,96 @@ export const rebootVPSServiceTool = createTool(
 
         vpsServiceToolsLogger.info(
             `Done sending reboot command to VPS ${args.serviceName} !`
+        )
+
+        return {
+            content: [{ type: 'text', text: output }],
+        }
+    }
+)
+
+export const startVPSServiceTool = createTool(
+    'vps_service_start',
+    'Request to start Virtual Private Server machine',
+    {
+        serviceName: serviceName,
+    },
+    {},
+    async (args, extra) => {
+        vpsServiceToolsLogger.info(
+            `Sending start command to VPS ${args.serviceName}...`
+        )
+
+        let status: object | null = null
+
+        try {
+            status = await OVHClient.requestPromised(
+                'POST',
+                `/vps/${args.serviceName}/start`
+            )
+        } catch (err: unknown) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(err),
+                    },
+                ],
+                isError: true,
+            }
+        }
+
+        const output = JSON.stringify({
+            status: status,
+        })
+
+        vpsServiceToolsLogger.info(
+            `Done sending start command to VPS ${args.serviceName} !`
+        )
+
+        return {
+            content: [{ type: 'text', text: output }],
+        }
+    }
+)
+
+export const stopVPSServiceTool = createTool(
+    'vps_service_stop',
+    'Request to stop Virtual Private Server machine',
+    {
+        serviceName: serviceName,
+    },
+    {},
+    async (args, extra) => {
+        vpsServiceToolsLogger.info(
+            `Sending stop command to VPS ${args.serviceName}...`
+        )
+
+        let status: object | null = null
+
+        try {
+            status = await OVHClient.requestPromised(
+                'POST',
+                `/vps/${args.serviceName}/stop`
+            )
+        } catch (err: unknown) {
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(err),
+                    },
+                ],
+                isError: true,
+            }
+        }
+
+        const output = JSON.stringify({
+            status: status,
+        })
+
+        vpsServiceToolsLogger.info(
+            `Done sending stop command to VPS ${args.serviceName} !`
         )
 
         return {
@@ -283,6 +373,8 @@ export const registerVPSServiceTools = (server: McpServer) => {
     registerTool(getConsoleUrlVPSServiceTool, server)
     registerTool(getIPAddressesVPSServiceTool, server)
     registerTool(rebootVPSServiceTool, server)
+    registerTool(startVPSServiceTool, server)
+    registerTool(stopVPSServiceTool, server)
     // Custom
     registerTool(executeCommandsVPSServiceTool, server)
 }

--- a/tests/tools/vps/service.spec.ts
+++ b/tests/tools/vps/service.spec.ts
@@ -23,6 +23,8 @@ import {
     getVPSServicePropertiesTool,
     rebootVPSServiceTool,
     registerVPSServiceTools,
+    startVPSServiceTool,
+    stopVPSServiceTool,
 } from '../../../src/tools/vps/service'
 import * as utils from '../../../src/utils'
 import { SSHCommandExecutionResult } from '../../../src/lib/ssh2/client'
@@ -234,6 +236,108 @@ describe('VPS service tools', () => {
         const toolDescription = rebootVPSServiceTool
 
         ovhClientRequestClientMock.mockImplementation(async () =>
+            Promise.reject(errorMock)
+        )
+
+        const result: any = await toolDescription.cb(
+            {
+                serviceName: 'vps-abcdefgh.vps.ovh.net',
+            },
+            {} as any
+        )
+
+        const content = JSON.parse(result['content'][0]['text'])
+
+        expect(content).toEqual(errorMock)
+    })
+
+    test('should start VPS', async () => {
+        const responseMock = {
+            date: '2025-05-13T08:35:24.294Z',
+            id: 0,
+            progress: 0,
+            state: 'blocked',
+            type: 'addVeeamBackupJob',
+        }
+
+        const toolDescription = startVPSServiceTool
+
+        ovhClientRequestClientMock.mockImplementation(() => responseMock)
+
+        const result: any = await toolDescription.cb(
+            {
+                serviceName: 'vps-abcdefgh.vps.ovh.net',
+            },
+            {} as any
+        )
+
+        const content = JSON.parse(result['content'][0]['text'])
+
+        const status = content['status']
+
+        expect(status).toEqual(responseMock)
+    })
+
+    test('should handle start VPS errors', async () => {
+        const errorMock = JSON.stringify({
+            error: 400,
+            message: 'Error mock',
+        })
+
+        const toolDescription = startVPSServiceTool
+
+        ovhClientRequestClientMock.mockImplementation(() =>
+            Promise.reject(errorMock)
+        )
+
+        const result: any = await toolDescription.cb(
+            {
+                serviceName: 'vps-abcdefgh.vps.ovh.net',
+            },
+            {} as any
+        )
+
+        const content = JSON.parse(result['content'][0]['text'])
+
+        expect(content).toEqual(errorMock)
+    })
+
+    test('should stop VPS', async () => {
+        const responseMock = {
+            date: '2025-05-13T08:29:30.572Z',
+            id: 0,
+            progress: 0,
+            state: 'blocked',
+            type: 'addVeeamBackupJob',
+        }
+
+        const toolDescription = stopVPSServiceTool
+
+        ovhClientRequestClientMock.mockImplementation(() => responseMock)
+
+        const result: any = await toolDescription.cb(
+            {
+                serviceName: 'vps-abcdefgh.vps.ovh.net',
+            },
+            {} as any
+        )
+
+        const content = JSON.parse(result['content'][0]['text'])
+
+        const status = content['status']
+
+        expect(status).toEqual(responseMock)
+    })
+
+    test('should handle stop VPS errors', async () => {
+        const errorMock = JSON.stringify({
+            error: 400,
+            message: 'Error mock',
+        })
+
+        const toolDescription = stopVPSServiceTool
+
+        ovhClientRequestClientMock.mockImplementation(() =>
             Promise.reject(errorMock)
         )
 


### PR DESCRIPTION
# Description

This PR aims to support /start and /stop endpoints for VPS AP

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How has this been tested ?

Unit tests full coverage

**Test Configuration**:

- Node.js Version: 22.13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
